### PR TITLE
fix: Initialize MPointerType in PyInit_sdsmemtools

### DIFF
--- a/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/main.c
+++ b/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/main.c
@@ -26,6 +26,9 @@ PyInit_sdsmemtools(void)
     if (PyType_Ready(&MemViewType) < 0)
         return NULL;
 
+    if (PyType_Ready(&MPointerType) < 0)
+        return NULL;
+
     module = PyModule_Create(&sdsmemtools_module);
     if (module == NULL)
         return NULL;

--- a/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/mpointer.c
+++ b/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/mpointer.c
@@ -13,10 +13,12 @@ PyVarObject_HEAD_INIT(NULL, 0)
     .tp_name = "MPointer",
     .tp_basicsize = sizeof(MPointer),
     .tp_itemsize = 0,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,
     .tp_new = MPointer_new,
     .tp_init = (initproc)MPointer_init,
     .tp_dealloc = (destructor)MPointer_dealloc,
+    .tp_traverse = (traverseproc)MPointer_traverse,
+    .tp_clear = (inquiry)MPointer_clear,
     .tp_members = MPointer_members,
     .tp_methods = MPointer_methods
 };


### PR DESCRIPTION
## 😊 개요
Fixes a segmentation fault on interpreter exit by calling PyType_Ready for MPointerType in the PyInit_sdsmemtools function. The type was not being properly initialized, leading to a crash during garbage collection.

## 🔎 구현한 내용
Fixes a segmentation fault on interpreter exit by calling PyType_Ready for MPointerType in the PyInit_sdsmemtools function. The type was not being properly initialized, leading to a crash during garbage collection.

## 📸 스크린샷 (선택)
<img width="732" height="374" alt="Screenshot 2025-08-07 at 20 03 22" src="https://github.com/user-attachments/assets/6f2a3830-4ef5-4176-a1e3-ac552dfd332e" />

## 🙌 리뷰어에게
