### PR TITLE
fix: Remove _retain_memory assignment in MemView_assign

### DIFF
--- a/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/memview_methods.c
+++ b/src/SDS_Serverless_Data_Shield/sds_mem_tools/src/memview_methods.c
@@ -165,7 +165,6 @@ MemView_assign(MemView* self, PyObject* other)
         }
     }
     self->type = STR_MEM_TYPE;
-    self->_retain_memory = false;
     memcpy(self->data, str, self->size);
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
## 😊 개요
`retain_mem`활성화하여도 `pointer`메소드를 사용할 수 없는 오류 수정

## 🔎 구현한 내용
`assign`함수내에 `retain_mem = false`로 인한 플래그 비활성화 문제 해결